### PR TITLE
Configure cameraParam by API

### DIFF
--- a/visual-tests/scene3d/scene3d-test.cpp
+++ b/visual-tests/scene3d/scene3d-test.cpp
@@ -155,36 +155,6 @@ public:
   }
 
 private:
-  void ConfigureCamera(const CameraParameters &params, CameraActor camera) {
-    if (params.isPerspective) {
-      camera.SetProjectionMode(Camera::PERSPECTIVE_PROJECTION);
-      camera.SetNearClippingPlane(params.zNear);
-      camera.SetFarClippingPlane(params.zFar);
-      camera.SetFieldOfView(Radian(Degree(params.yFov)));
-    } else {
-      camera.SetProjectionMode(Camera::ORTHOGRAPHIC_PROJECTION);
-      camera.SetOrthographicProjection(
-          params.orthographicSize.x, params.orthographicSize.y,
-          params.orthographicSize.z, params.orthographicSize.w, params.zNear,
-          params.zFar);
-    }
-
-    // model
-    Vector3 camTranslation;
-    Vector3 camScale;
-    Quaternion camOrientation;
-    params.CalculateTransformComponents(camTranslation, camOrientation,
-                                        camScale);
-
-    SetActorCentered(camera);
-    camera.SetInvertYAxis(true);
-    camera.SetProperty(Actor::Property::POSITION, camTranslation);
-    camera.SetProperty(Actor::Property::ORIENTATION, camOrientation);
-    camera.SetProperty(Actor::Property::SCALE, camScale);
-
-    camOrientation.Conjugate();
-  }
-
   Actor LoadScene(std::string sceneName, CameraActor camera) {
     ResourceBundle::PathProvider pathProvider = [](ResourceType::Value type) {
       return RESOURCE_TYPE_DIRS[type];
@@ -212,7 +182,9 @@ private:
       cameraParameters.push_back(CameraParameters());
       cameraParameters[0].matrix.SetTranslation(CAMERA_DEFAULT_POSITION);
     }
-    ConfigureCamera(cameraParameters[0], camera);
+
+    cameraParameters[0].ConfigureCamera(camera);
+    SetActorCentered(camera);
 
     ViewProjection viewProjection = cameraParameters[0].GetViewProjection();
     Transforms xforms{MatrixStack{}, viewProjection};


### PR DESCRIPTION
Let scene3d example camera configure cameraActor by API, not the sample's own logic.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>