### PR TITLE
Include dali-scene3d/dali-scene3d.h

### DIFF
--- a/visual-tests/scene3d/scene3d-test.cpp
+++ b/visual-tests/scene3d/scene3d-test.cpp
@@ -17,13 +17,7 @@
 
 // EXTERNAL INCLUDES
 #include <cstdio>
-#include <dali-scene3d/public-api/loader/animation-definition.h>
-#include <dali-scene3d/public-api/loader/camera-parameters.h>
-#include <dali-scene3d/public-api/loader/model-loader.h>
-#include <dali-scene3d/public-api/loader/light-parameters.h>
-#include <dali-scene3d/public-api/loader/load-result.h>
-#include <dali-scene3d/public-api/loader/node-definition.h>
-#include <dali-scene3d/public-api/loader/scene-definition.h>
+#include <dali-scene3d/dali-scene3d.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali-toolkit/devel-api/image-loader/texture-manager.h>
 #include <dali/dali.h>


### PR DESCRIPTION
Let we make scene3d demo app include dali-scene3d.h instead of include file-by-file.