### PR TITLE
Sets the Text component's Inset option to True

### DIFF
--- a/visual-tests/text-outline/text-outline-test.cpp
+++ b/visual-tests/text-outline/text-outline-test.cpp
@@ -77,8 +77,11 @@ class TextOutlineTest: public VisualTest
       mTextLabel[i] = TextLabel::New();
       mTextLabel[i].SetProperty( Actor::Property::PARENT_ORIGIN,ParentOrigin::TOP_LEFT);
       mTextLabel[i].SetProperty( Actor::Property::ANCHOR_POINT,AnchorPoint::TOP_LEFT);
+
+      // TODO : Since 2.3.32, we change the default value of REMOVE_FRONT_INSET and REMOVE_BACK_INSET as false.
       mTextLabel[i].SetProperty( DevelTextLabel::Property::REMOVE_FRONT_INSET, true);
       mTextLabel[i].SetProperty( DevelTextLabel::Property::REMOVE_BACK_INSET, true);
+
       mTextLabel[i].SetProperty( TextLabel::Property::OUTLINE, outlineMap );
       window.Add( mTextLabel[i] );
     }

--- a/visual-tests/text-outline/text-outline-test.cpp
+++ b/visual-tests/text-outline/text-outline-test.cpp
@@ -20,6 +20,7 @@
 #include <dali/dali.h>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
 #include <dali-toolkit/dali-toolkit.h>
+#include <dali-toolkit/devel-api/controls/text-controls/text-label-devel.h>
 #include <cstdlib>
 
 // INTERNAL INCLUDES
@@ -76,6 +77,8 @@ class TextOutlineTest: public VisualTest
       mTextLabel[i] = TextLabel::New();
       mTextLabel[i].SetProperty( Actor::Property::PARENT_ORIGIN,ParentOrigin::TOP_LEFT);
       mTextLabel[i].SetProperty( Actor::Property::ANCHOR_POINT,AnchorPoint::TOP_LEFT);
+      mTextLabel[i].SetProperty( DevelTextLabel::Property::REMOVE_FRONT_INSET, true);
+      mTextLabel[i].SetProperty( DevelTextLabel::Property::REMOVE_BACK_INSET, true);
       mTextLabel[i].SetProperty( TextLabel::Property::OUTLINE, outlineMap );
       window.Add( mTextLabel[i] );
     }

--- a/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
+++ b/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
@@ -73,6 +73,8 @@ public:
     mTextLabel.SetProperty(TextLabel::Property::POINT_SIZE, 200);
     mTextLabel.SetProperty(TextLabel::Property::ELLIPSIS, false);
     mTextLabel.SetProperty(TextLabel::Property::MULTI_LINE, true);
+
+    // TODO : Since 2.3.32, we change the default value of REMOVE_FRONT_INSET and REMOVE_BACK_INSET as false.
     mTextLabel.SetProperty(DevelTextLabel::Property::REMOVE_FRONT_INSET, true);
     mTextLabel.SetProperty(DevelTextLabel::Property::REMOVE_BACK_INSET, true);
 
@@ -83,6 +85,8 @@ public:
                             AnchorPoint::TOP_LEFT);
     mTextEditor.SetProperty(Actor::Property::POSITION, Vector3(0.f, 0.0f, 0.f));
     mTextEditor.SetProperty(TextEditor::Property::POINT_SIZE, 200);
+
+    // TODO : Since 2.3.32, we change the default value of REMOVE_FRONT_INSET and REMOVE_BACK_INSET as false.
     mTextEditor.SetProperty(DevelTextEditor::Property::REMOVE_FRONT_INSET, true);
     mTextEditor.SetProperty(DevelTextEditor::Property::REMOVE_BACK_INSET, true);
 

--- a/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
+++ b/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
@@ -17,6 +17,8 @@
 
 // EXTERNAL INCLUDES
 #include <dali-toolkit/dali-toolkit.h>
+#include <dali-toolkit/devel-api/controls/text-controls/text-editor-devel.h>
+#include <dali-toolkit/devel-api/controls/text-controls/text-label-devel.h>
 #include <dali-toolkit/devel-api/text/text-enumerations-devel.h>
 #include <dali/dali.h>
 #include <string>
@@ -71,6 +73,8 @@ public:
     mTextLabel.SetProperty(TextLabel::Property::POINT_SIZE, 200);
     mTextLabel.SetProperty(TextLabel::Property::ELLIPSIS, false);
     mTextLabel.SetProperty(TextLabel::Property::MULTI_LINE, true);
+    mTextLabel.SetProperty(DevelTextLabel::Property::REMOVE_FRONT_INSET, true);
+    mTextLabel.SetProperty(DevelTextLabel::Property::REMOVE_BACK_INSET, true);
 
     mTextEditor = TextEditor::New();
     mTextEditor.SetProperty(Actor::Property::PARENT_ORIGIN,
@@ -79,6 +83,8 @@ public:
                             AnchorPoint::TOP_LEFT);
     mTextEditor.SetProperty(Actor::Property::POSITION, Vector3(0.f, 0.0f, 0.f));
     mTextEditor.SetProperty(TextEditor::Property::POINT_SIZE, 200);
+    mTextEditor.SetProperty(DevelTextEditor::Property::REMOVE_FRONT_INSET, true);
+    mTextEditor.SetProperty(DevelTextEditor::Property::REMOVE_BACK_INSET, true);
 
     mWindow.Add(mTextLabel);
     PerformNextTest();


### PR DESCRIPTION
The default value of removeFrontInset, removeBackInset set to false on Devel branch.

Patch:
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/314253