### PR TITLE
Reduce test duration

### DIFF
--- a/visual-tests/advanced-blending-mode/advanced-blending-mode-test.cpp
+++ b/visual-tests/advanced-blending-mode/advanced-blending-mode-test.cpp
@@ -111,18 +111,26 @@ public:
   {
     Window window = mApplication.GetWindow();
     Debug::LogMessage(Debug::INFO, "Resource loaded\n");
-    Debug::LogMessage(Debug::INFO, "Starting draw timer()\n");
-    mTimer = Timer::New(1000);
-    mTimer.TickSignal().Connect(this, &AdvancedBlendingModeTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &AdvancedBlendingModeTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &AdvancedBlendingModeTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -133,7 +141,6 @@ public:
 
 private:
   Application& mApplication;
-  Timer mTimer;
 };
 
 DALI_VISUAL_TEST_WITH_WINDOW_SIZE( AdvancedBlendingModeTest, OnInit, 720, 800 )

--- a/visual-tests/alpha-blending-cpu/alpha-blending-cpu-test.cpp
+++ b/visual-tests/alpha-blending-cpu/alpha-blending-cpu-test.cpp
@@ -118,18 +118,27 @@ private:
     readyCounter++;
     if(readyCounter == NUMBER_OF_IMAGES)
     {
-      mTimer = Timer::New(1000);
-      mTimer.TickSignal().Connect(this, &AlphaBlendingCpuTest::OnTimer);
-      mTimer.Start();
+      Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+      Animation firstFrameAnimator = Animation::New(0);
+      firstFrameAnimator.FinishedSignal().Connect(this, &AlphaBlendingCpuTest::OnAnimationFinished1);
+      firstFrameAnimator.Play();
     }
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &AlphaBlendingCpuTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -139,8 +148,7 @@ private:
   }
 
 private:
-  Application&   mApplication;
-  Timer mTimer;
+  Application& mApplication;
 };
 
 DALI_VISUAL_TEST_WITH_WINDOW_SIZE(AlphaBlendingCpuTest, OnInit, WINDOW_WIDTH, WINDOW_HEIGHT)

--- a/visual-tests/borderline-visual/borderline-visual-test.cpp
+++ b/visual-tests/borderline-visual/borderline-visual-test.cpp
@@ -34,8 +34,6 @@ using namespace Dali::Toolkit;
 
 namespace
 {
-const int DRAW_TIME{1000};
-
 // Resource for drawing
 const std::string JPG_FILENAME             = TEST_IMAGE_DIR "corner-radius-visual/gallery-medium-16.jpg";
 const std::string SVG_FILENAME             = TEST_IMAGE_DIR "corner-radius-visual/Contacts.svg";
@@ -180,7 +178,6 @@ private:
 
     gTermiatedTest = true;
     gExitValue = -1;
-    mTimer.Stop();
     mApplication.Quit();
 
     exit(gExitValue);
@@ -217,9 +214,7 @@ private:
     gAnimationFinished = true;
     if(gAnimationFinished && gResourceReadyCount == TOTAL_RESOURCES)
     {
-      mTimer = Timer::New(DRAW_TIME); // ms
-      mTimer.TickSignal().Connect(this, &BorderineVisualTest::OnTimer);
-      mTimer.Start();
+      StartDrawTimer();
     }
   }
 
@@ -229,18 +224,32 @@ private:
     gResourceReadyCount++;
     if(gAnimationFinished && gResourceReadyCount == TOTAL_RESOURCES)
     {
-      mTimer = Timer::New(DRAW_TIME); // ms
-      mTimer.TickSignal().Connect(this, &BorderineVisualTest::OnTimer);
-      mTimer.Start();
+      StartDrawTimer();
     }
   }
 
-  bool OnTimer()
+  void StartDrawTimer()
+  {
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &BorderineVisualTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &BorderineVisualTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -472,7 +481,6 @@ private:
 private:
   Application&         mApplication;
   Window               mWindow;
-  Timer                mTimer;
   Timer                mTerminateTimer;
   Animation            mAnimation;
   std::vector<Control> mControlList;

--- a/visual-tests/clipping-draw-order/clipping-draw-order-test.cpp
+++ b/visual-tests/clipping-draw-order/clipping-draw-order-test.cpp
@@ -18,6 +18,7 @@
 // EXTERNAL INCLUDES
 #include <string>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali-toolkit/devel-api/controls/table-view/table-view.h>
 
@@ -29,8 +30,6 @@ using namespace Dali::Toolkit;
 
 namespace
 {
-const int DRAW_TIME{1000};
-
 constexpr const char* IMAGES[] = {
   TEST_IMAGE_DIR "clipping-draw-order/gallery-small-1.jpg",
   TEST_IMAGE_DIR "clipping-draw-order/gallery-small-2.jpg",
@@ -167,17 +166,27 @@ private:
     readyCounter++;
     if(readyCounter == NUMBER_OF_IMAGE_VIEWS)
     {
-      mTimer = Timer::New(DRAW_TIME);
-      mTimer.TickSignal().Connect(this, &ClippingDrawOrderVerification::OnTimer);
-      mTimer.Start();
+      Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+      Animation firstFrameAnimator = Animation::New(0);
+      firstFrameAnimator.FinishedSignal().Connect(this, &ClippingDrawOrderVerification::OnAnimationFinished1);
+      firstFrameAnimator.Play();
     }
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &ClippingDrawOrderVerification::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    CaptureWindow( window );
-    return false;
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)

--- a/visual-tests/clipping-mode/clipping-mode-test.cpp
+++ b/visual-tests/clipping-mode/clipping-mode-test.cpp
@@ -226,17 +226,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000);
-    mTimer.TickSignal().Connect(this, &ClippingModeTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &ClippingModeTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &ClippingModeTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void PostRender(std::string outputFile, bool success)

--- a/visual-tests/corner-radius-visual/corner-radius-visual-test.cpp
+++ b/visual-tests/corner-radius-visual/corner-radius-visual-test.cpp
@@ -18,6 +18,7 @@
 // EXTERNAL INCLUDES
 #include <string>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali-toolkit/devel-api/controls/control-devel.h>
 #include <dali-toolkit/devel-api/visuals/visual-properties-devel.h>
@@ -168,7 +169,6 @@ private:
 
     gTerminatedTest = true;
     gExitValue = -1;
-    mTimer.Stop();
     mApplication.Quit();
 
     exit(gExitValue);
@@ -221,15 +221,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000); // Plenty of time to draw to fb
-    mTimer.TickSignal().Connect(this, &CornerRadiusVisualTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &CornerRadiusVisualTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
-    CaptureWindow(mApplication.GetWindow());
-    return false;
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &CornerRadiusVisualTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Window window = mApplication.GetWindow();
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -494,7 +505,6 @@ private:
 private:
   Application&         mApplication;
   Window               mWindow;
-  Timer                mTimer;
   Timer                mTerminateTimer;
   Animation            mAnimation;
   std::vector<Control> mControlList;

--- a/visual-tests/empty-scene-clear/empty-scene-clear-test.cpp
+++ b/visual-tests/empty-scene-clear/empty-scene-clear-test.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <dali/dali.h>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali/devel-api/adaptor-framework/window-devel.h>
 
@@ -121,15 +122,25 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000); // Plenty of time to draw to fb
-    mTimer.TickSignal().Connect(this, &EmptySceneClearTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &EmptySceneClearTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &EmptySceneClearTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(mTestWindow);
-    return false;
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -153,7 +164,6 @@ private:
   Dali::Window mSecondWindow;
   Dali::Window mThirdWindow;
   TextLabel    mTextLabel;
-  Timer mTimer;
 };
 
 DALI_VISUAL_TEST( EmptySceneClearTest, OnInit )

--- a/visual-tests/remote-download/remote-download-test.cpp
+++ b/visual-tests/remote-download/remote-download-test.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <dali/dali.h>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali-toolkit/devel-api/visuals/image-visual-properties-devel.h>
 #include <dali-toolkit/devel-api/visual-factory/visual-factory.h>
@@ -97,15 +98,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000); // Plenty of time to draw to fb
-    mTimer.TickSignal().Connect(this, &RemoteDownloadTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &RemoteDownloadTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
-    CaptureWindow(mApplication.GetWindow());
-    return false;
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &RemoteDownloadTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Window window = mApplication.GetWindow();
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -118,7 +130,6 @@ private:
 private:
   Application&   mApplication;
   ImageView      mImageViews[NUMBER_OF_IMAGES];
-  Timer          mTimer;
 };
 
 DALI_VISUAL_TEST_WITH_WINDOW_SIZE( RemoteDownloadTest, OnInit, 1024, 960 )

--- a/visual-tests/scene3d/scene3d-test.cpp
+++ b/visual-tests/scene3d/scene3d-test.cpp
@@ -36,7 +36,6 @@ namespace
 {
 
   const Vector3 CAMERA_DEFAULT_POSITION(0.0f, 0.0f, 3.5f);
-  const unsigned int DEFAULT_DRAW_TIMER = 1000;
 
   const std::string RESOURCE_TYPE_DIRS[]{
       TEST_SCENE_DIR "environments/",
@@ -155,7 +154,7 @@ private:
         mScene = LoadScene("exercise.dli", mSceneCamera);
         mSceneLayer.Add(mScene);
 
-        StartDrawTimer(DEFAULT_DRAW_TIMER);
+        StartDrawTimer();
         break;
       }
     case FIRST_SCENE_ANIMATION:
@@ -166,7 +165,7 @@ private:
       }
       else
       {
-        StartDrawTimer(DEFAULT_DRAW_TIMER);
+        StartDrawTimer();
       }
       break;
     }
@@ -175,7 +174,7 @@ private:
       UnparentAndReset(mScene);
       mScene = LoadScene("robot.dli", mSceneCamera);
       mSceneLayer.Add(mScene);
-      StartDrawTimer(DEFAULT_DRAW_TIMER);
+      StartDrawTimer();
       break;
     }
     case SECOND_SCENE_ANIMATION:
@@ -186,7 +185,7 @@ private:
       }
       else
       {
-        StartDrawTimer(DEFAULT_DRAW_TIMER);
+        StartDrawTimer();
       }
       break;
     }
@@ -196,7 +195,7 @@ private:
       mScene = LoadScene("beer.dli", mSceneCamera);
       mSceneLayer.Add(mScene);
 
-      StartDrawTimer(DEFAULT_DRAW_TIMER);
+      StartDrawTimer();
       break;
     }
     default:
@@ -204,24 +203,33 @@ private:
     }
   }
 
-  void StartDrawTimer(int millisecond)
+  void StartDrawTimer()
   {
-    mTimer = Timer::New(millisecond);
-    mTimer.TickSignal().Connect(this, &Scene3DTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &Scene3DTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &Scene3DTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void OnFinishedAnimation(Animation& animation)
   {
-    StartDrawTimer(DEFAULT_DRAW_TIMER);
+    StartDrawTimer();
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -328,7 +336,6 @@ private:
 
 private:
   Application &mApplication;
-  Timer mTimer;
   CameraActor mSceneCamera;
   Actor mScene;
   Layer mSceneLayer;

--- a/visual-tests/text-outline/text-outline-test.cpp
+++ b/visual-tests/text-outline/text-outline-test.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <dali/dali.h>
 #include <dali/integration-api/adaptor-framework/adaptor.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali-toolkit/devel-api/controls/text-controls/text-label-devel.h>
 #include <cstdlib>
@@ -171,15 +172,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000); // Plenty of time to draw to fb
-    mTimer.TickSignal().Connect(this, &TextOutlineTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &TextOutlineTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
-    CaptureWindow(mApplication.GetWindow());
-    return false;
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &TextOutlineTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Window window = mApplication.GetWindow();
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -202,7 +214,6 @@ private:
 private:
   Application&            mApplication;
   TextLabel               mTextLabel[6];
-  Timer mTimer;
 };
 
 DALI_VISUAL_TEST_WITH_WINDOW_SIZE( TextOutlineTest, OnInit, 1000, 850 )

--- a/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
+++ b/visual-tests/text-wrapping-hyphen/text-wrapping-hyphen-test.cpp
@@ -21,6 +21,7 @@
 #include <dali-toolkit/devel-api/controls/text-controls/text-label-devel.h>
 #include <dali-toolkit/devel-api/text/text-enumerations-devel.h>
 #include <dali/dali.h>
+#include <dali/integration-api/debug.h>
 #include <string>
 
 // INTERNAL INCLUDES
@@ -160,15 +161,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000);
-    mTimer.TickSignal().Connect(this, &TextWrappingTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &TextWrappingTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
-    CaptureWindow(mWindow);
-    return false;
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &TextWrappingTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Window window = mApplication.GetWindow();
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -190,7 +202,6 @@ private:
   Dali::Window mWindow;
   TextLabel mTextLabel;
   TextEditor mTextEditor;
-  Timer mTimer;
 };
 
 DALI_VISUAL_TEST_WITH_WINDOW_SIZE(TextWrappingTest, OnInit, 900, 900)

--- a/visual-tests/transform-update/transform-update-test.cpp
+++ b/visual-tests/transform-update/transform-update-test.cpp
@@ -18,6 +18,7 @@
 // EXTERNAL INCLUDES
 #include <string>
 #include <dali/dali.h>
+#include <dali/integration-api/debug.h>
 #include <dali-toolkit/dali-toolkit.h>
 
 // INTERNAL INCLUDES

--- a/visual-tests/usd-model/usd-model-test.cpp
+++ b/visual-tests/usd-model/usd-model-test.cpp
@@ -35,7 +35,6 @@ using namespace Dali::Scene3D::Loader;
 namespace
 {
 const Vector3      CAMERA_DEFAULT_POSITION(0.0f, 0.0f, 3.5f);
-const unsigned int DEFAULT_DRAW_TIMER = 1000;
 
 const std::string RESOURCE_TYPE_DIRS[]{
   TEST_SCENE_DIR "environments/",
@@ -155,27 +154,36 @@ private:
 
     mSceneLayer.Add(mScene);
 
-    StartDrawTimer(DEFAULT_DRAW_TIMER);
+    StartDrawTimer();
   }
 
-  void StartDrawTimer(int millisecond)
+  void StartDrawTimer()
   {
-    mTimer = Timer::New(millisecond);
-    mTimer.TickSignal().Connect(this, &UsdModelTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &UsdModelTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
+  {
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &UsdModelTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
   {
     Window window = mApplication.GetWindow();
-    Debug::LogMessage(Debug::INFO, "Draw timer finished. Capturing window\n");
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
     CaptureWindow(window);
-    return false;
   }
 
   void OnFinishedAnimation(Animation& animation)
   {
-    StartDrawTimer(DEFAULT_DRAW_TIMER);
+    StartDrawTimer();
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -265,7 +273,6 @@ private:
 
 private:
   Application& mApplication;
-  Timer        mTimer;
   CameraActor  mSceneCamera;
   Actor        mScene;
   Layer        mSceneLayer;

--- a/visual-tests/window-resize/window-resize-test.cpp
+++ b/visual-tests/window-resize/window-resize-test.cpp
@@ -18,6 +18,7 @@
 // EXTERNAL INCLUDES
 #include <dali-toolkit/dali-toolkit.h>
 #include <dali/dali.h>
+#include <dali/integration-api/debug.h>
 
 #include <string>
 
@@ -90,15 +91,26 @@ private:
 
   void StartDrawTimer()
   {
-    mTimer = Timer::New(1000);
-    mTimer.TickSignal().Connect(this, &WindowResizeTest::OnTimer);
-    mTimer.Start();
+    Debug::LogMessage(Debug::INFO, "Starting draw and check()\n");
+
+    Animation firstFrameAnimator = Animation::New(0);
+    firstFrameAnimator.FinishedSignal().Connect(this, &WindowResizeTest::OnAnimationFinished1);
+    firstFrameAnimator.Play();
   }
 
-  bool OnTimer()
+  void OnAnimationFinished1(Animation& /* not used */)
   {
-    CaptureWindow(mApplication.GetWindow());
-    return false;
+    Debug::LogMessage(Debug::INFO, "First Update done()\n");
+    Animation secondFrameAnimator = Animation::New(0);
+    secondFrameAnimator.FinishedSignal().Connect(this, &WindowResizeTest::OnAnimationFinished2);
+    secondFrameAnimator.Play();
+  }
+
+  void OnAnimationFinished2(Animation& /* not used */)
+  {
+    Window window = mApplication.GetWindow();
+    Debug::LogMessage(Debug::INFO, "Second Update done(). We can assume that at least 1 frame rendered now. Capturing window\n");
+    CaptureWindow(window);
   }
 
   void PostRender(std::string outputFile, bool success)
@@ -119,7 +131,6 @@ private:
 private:
   Application& mApplication;
   Actor        mActor;
-  Timer        mTimer;
 };
 
 DALI_VISUAL_TEST(WindowResizeTest, OnInit)


### PR DESCRIPTION
Let we use AnimationFinished callback instead Timer. It will ensure that we render at least 1 frames.

execute time changed 60s -> 32s

TODO : Below 3 tests looks need to refactorize if we want to remove Timer.

resource-uploading
multiple-window-creation-deletion
collider-mesh